### PR TITLE
fix: remove the protocol to let browser decide

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ need to load. You'll see a lot of <link>s to CSS files for styles and
   <!-- Load the page styles. -->
   <link href="css/style.css" rel="stylesheet">
 
-  <script src="http://maps.googleapis.com/maps/api/js?libraries=places"></script>
+  <script src="//maps.googleapis.com/maps/api/js?libraries=places"></script>
 
   <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>


### PR DESCRIPTION
Removed the http protocol on google maps api request to let
the browser decide which ever he want to use.