### PR TITLE
fix: header contacts color changed to orange

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -132,7 +132,7 @@ a {
   background-color: #484848;
 }
 
-#header span {
+#header > span {
   color: #fff;
 }
 


### PR DESCRIPTION
Header color of contacts is changed back to orange. The color white was
applied mistakengly due to 'header span' selector but converting it to the
correct 'header > span' selector would apply it only on designation span.